### PR TITLE
Add support for proxies when connecting to SSH remotes

### DIFF
--- a/guild/remotes/ssh.py
+++ b/guild/remotes/ssh.py
@@ -53,6 +53,7 @@ class SSHRemote(remotelib.Remote):
         self.venv_activate = config.get("venv-activate")
         self.use_prerelease = config.get("use-prerelease", False)
         self.init = config.get("init")
+        self.proxy = config.get("proxy")
 
     @staticmethod
     def _init_guild_home(config, venv_path):
@@ -87,7 +88,8 @@ class SSHRemote(remotelib.Remote):
             ssh_util.rsync_ssh_opts(
                 remote_util.config_path(self.private_key),
                 self.connect_timeout,
-                self.port))
+                self.port,
+                self.proxy))
         log.info("Copying %s", run.id)
         log.debug("rsync cmd: %r", cmd)
         subprocess.check_call(cmd)
@@ -105,7 +107,8 @@ class SSHRemote(remotelib.Remote):
             ssh_util.rsync_ssh_opts(
                 remote_util.config_path(self.private_key),
                 self.connect_timeout,
-                self.port))
+                self.port,
+                self.proxy))
         log.info("Copying %s", run.id)
         log.debug("rsync cmd: %r", cmd)
         subprocess.check_call(cmd)
@@ -147,7 +150,8 @@ class SSHRemote(remotelib.Remote):
             private_key=self.private_key,
             verbose=verbose,
             connect_timeout=self.connect_timeout,
-            port=self.port)
+            port=self.port,
+            proxy=self.proxy)
         sys.stdout.write("%s (%s) is available\n" % (self.name, self.host))
 
     def run_op(self, opspec, flags, restart, no_wait, stage, **opts):
@@ -214,7 +218,8 @@ class SSHRemote(remotelib.Remote):
             user=self.user,
             private_key=remote_util.config_path(self.private_key),
             connect_timeout=self.connect_timeout,
-            port=self.port)
+            port=self.port,
+            proxy=self.proxy)
 
     def _init_remote_new_run_dir(self, opspec):
         run_id = runlib.mkid()
@@ -241,7 +246,8 @@ class SSHRemote(remotelib.Remote):
             src, self.host, host_dest,
             user=self.user,
             private_key=remote_util.config_path(self.private_key),
-            port=self.port)
+            port=self.port,
+            proxy=self.proxy)
 
     def _install_job_package(self, remote_run_dir):
         cmd_lines = []
@@ -321,7 +327,8 @@ class SSHRemote(remotelib.Remote):
             user=self.user,
             private_key=remote_util.config_path(self.private_key),
             connect_timeout=self.connect_timeout,
-            port=self.port)
+            port=self.port,
+            proxy=self.proxy)
 
     def _env_activate_cmd_lines(self):
         return util.find_apply([

--- a/guild/remotes/ssh_util.py
+++ b/guild/remotes/ssh_util.py
@@ -24,15 +24,24 @@ log = logging.getLogger("guild.remotes.ssh_util")
 
 DEFAULT_CONNECT_TIMEOUT = 10
 
-def ssh_ping(host, user=None, private_key=None, verbose=False,
-             connect_timeout=DEFAULT_CONNECT_TIMEOUT, port=None):
+
+def ssh_ping(
+    host,
+    user=None,
+    private_key=None,
+    verbose=False,
+    connect_timeout=DEFAULT_CONNECT_TIMEOUT,
+    port=None,
+    proxy=None,
+):
     host = _full_host(host, user)
-    opts = _ssh_opts(private_key, verbose, connect_timeout, port)
+    opts = _ssh_opts(private_key, verbose, connect_timeout, port, proxy)
     cmd = ["ssh"] + opts + [host, "true"]
     log.debug("ssh cmd: %r", cmd)
     result = subprocess.call(cmd)
     if result != 0:
         raise remotelib.Down("cannot reach host %s" % host)
+
 
 def _full_host(host, user):
     if user:
@@ -40,36 +49,53 @@ def _full_host(host, user):
     else:
         return host
 
-def ssh_cmd(host, cmd, user=None, private_key=None,
-            connect_timeout=DEFAULT_CONNECT_TIMEOUT, port=None):
-    cmd = _ssh_cmd(host, cmd, user, private_key, connect_timeout, port)
+
+def ssh_cmd(
+    host,
+    cmd,
+    user=None,
+    private_key=None,
+    connect_timeout=DEFAULT_CONNECT_TIMEOUT,
+    port=None,
+    proxy=None,
+):
+    cmd = _ssh_cmd(host, cmd, user, private_key, connect_timeout, port, proxy)
     log.debug("ssh cmd: %r", cmd)
     try:
         subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:
         raise remotelib.RemoteProcessError.from_called_process_error(e)
 
-def _ssh_cmd(host, cmd, user, private_key, connect_timeout, port):
+
+def _ssh_cmd(host, cmd, user, private_key, connect_timeout, port, proxy):
     host = _full_host(host, user)
     return (
-        ["ssh"] +
-        _ssh_opts(private_key, False, connect_timeout, port) +
-        [host] +
-        cmd)
+        ["ssh"]
+        + _ssh_opts(private_key, False, connect_timeout, port, proxy)
+        + [host]
+        + cmd
+    )
 
-def ssh_output(host, cmd, user=None, private_key=None,
-               connect_timeout=DEFAULT_CONNECT_TIMEOUT, port=None):
-    cmd = _ssh_cmd(host, cmd, user, private_key, connect_timeout, port)
+
+def ssh_output(
+    host,
+    cmd,
+    user=None,
+    private_key=None,
+    connect_timeout=DEFAULT_CONNECT_TIMEOUT,
+    port=None,
+    proxy=None,
+):
+    cmd = _ssh_cmd(host, cmd, user, private_key, connect_timeout, port, proxy)
     log.debug("ssh cmd: %r", cmd)
     try:
         return subprocess.check_output(cmd)
     except subprocess.CalledProcessError as e:
         raise remotelib.RemoteProcessError.from_called_process_error(e)
 
-def _ssh_opts(private_key, verbose, connect_timeout, port):
-    opts = [
-        "-oStrictHostKeyChecking=no"
-    ]
+
+def _ssh_opts(private_key, verbose, connect_timeout, port, proxy):
+    opts = ["-oStrictHostKeyChecking=no"]
     if private_key:
         opts.extend(["-i", private_key])
     if verbose:
@@ -78,17 +104,30 @@ def _ssh_opts(private_key, verbose, connect_timeout, port):
         opts.append("-oConnectTimeout=%s" % connect_timeout)
     if port:
         opts.extend(["-p", str(port)])
+    if proxy:
+        opts.append("-oProxyCommand=%s" % proxy)
     return opts
 
-def rsync_copy_to(src, host, host_dest, user=None, private_key=None,
-                  connect_timeout=DEFAULT_CONNECT_TIMEOUT, port=None):
+
+def rsync_copy_to(
+    src,
+    host,
+    host_dest,
+    user=None,
+    private_key=None,
+    connect_timeout=DEFAULT_CONNECT_TIMEOUT,
+    port=None,
+    proxy=None,
+):
     dest = format_rsync_host_path(host, host_dest, user)
     cmd = (
-        ["rsync", "-vr"] +
-        rsync_ssh_opts(private_key, connect_timeout, port) +
-        [src, dest])
+        ["rsync", "-vr"]
+        + rsync_ssh_opts(private_key, connect_timeout, port, proxy)
+        + [src, dest]
+    )
     log.debug("rsync cmd: %r", cmd)
     subprocess.check_call(cmd)
+
 
 def format_rsync_host_path(host, path, user):
     if user:
@@ -96,11 +135,13 @@ def format_rsync_host_path(host, path, user):
     else:
         return "{}:{}".format(host, path)
 
-def rsync_ssh_opts(private_key=None, connect_timeout=None, port=None):
-    ssh_cmd = _rsync_ssh_cmd(private_key, connect_timeout, port)
+
+def rsync_ssh_opts(private_key=None, connect_timeout=None, port=None, proxy=None):
+    ssh_cmd = _rsync_ssh_cmd(private_key, connect_timeout, port, proxy)
     return ["-e", ssh_cmd]
 
-def _rsync_ssh_cmd(private_key, connect_timeout, port):
+
+def _rsync_ssh_cmd(private_key, connect_timeout, port, proxy):
     parts = ["ssh"]
     if private_key:
         parts.append("-i '%s'" % private_key)
@@ -108,4 +149,6 @@ def _rsync_ssh_cmd(private_key, connect_timeout, port):
         parts.append("-oConnectTimeout=%s" % connect_timeout)
     if port:
         parts.append("-p %s" % port)
+    if proxy:
+        parts.append("-o 'ProxyCommand %s'" % proxy)
     return " ".join(parts)


### PR DESCRIPTION
Pull request providing code for #83.

The corresponding config.yml is extended by the option _proxy_:
```
remotes:
  aws:
    type: ssh
    host: XXX.XXX.XXX.XXX
    user: <username>
    proxy: nc -x <ip-proxy>:<port> %h %p
```

I was not sure about how to include this in the tests. Let me know if you would like to change or add something :)