### PR TITLE
Fix incorrect parsing of random_seed, max_trials and stop_after when using --remote option

### DIFF
--- a/guild/remotes/ssh.py
+++ b/guild/remotes/ssh.py
@@ -559,7 +559,7 @@ def _remote_run_cmd(
     if needed:
         cmd.append("--needed")
     if stop_after:
-        cmd.extend(["--stop-after", stop_after])
+        cmd.extend(["--stop-after", str(stop_after)])
     if optimize:
         cmd.append("--optimize")
     if optimizer:
@@ -571,9 +571,9 @@ def _remote_run_cmd(
     if maximize:
         cmd.extend(["--maximize", maximize])
     if random_seed is not None:
-        cmd.extend(["--random-seed", random_seed])
+        cmd.extend(["--random-seed", str(random_seed)])
     if max_trials is not None:
-        cmd.extend(["--max-trials", max_trials])
+        cmd.extend(["--max-trials", str(max_trials)])
     if init_trials:
         cmd.append("--init-trials")
     cmd.extend([q(arg) for arg in op_flags])


### PR DESCRIPTION
There is a bug in the remote_ssh command that makes it impossible to set `random_seed`, `max_trials` or `stop_after` when using `--remote` option. The problem is that simply converting them to strings in `_remote_run_cmd` function is missing.

Therefore, it would end with the following error
```
  File ".../guild/remotes/ssh.py", line 577, in _remote_run_cmd
    return " ".join(cmd)
TypeError: sequence item 11: expected str instance, int found
```

This pull request fixes this issue.

Thanks @devmood for finding the error and for help to find the solution!