### PR TITLE
Fix Docker environment and improve reproducibility

### DIFF
--- a/package/docker/guildai/Dockerfile
+++ b/package/docker/guildai/Dockerfile
@@ -1,22 +1,27 @@
-FROM ubuntu
+FROM ubuntu:18.04
 
-RUN apt-get update -y
-RUN apt-get upgrade -y
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
 
-RUN apt-get install -y wget
-RUN apt-get install -y unzip
-RUN apt-get install -y python
-RUN apt-get install -y python-pip
+RUN apt-get update --assume-yes \
+    && apt-get install --assume-yes \
+        wget \
+        unzip \
+        python3 \
+        python3-pip \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 2 \
+    && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 2 \
+    &&  rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
-RUN pip install --pre guildai
-RUN pip install tensorflow
+RUN pip install --pre guildai \
+    && pip install tensorflow \
+    && pip install virtualenv==16
 
 WORKDIR /root
 
-RUN wget -q https://github.com/guildai/examples/archive/master.zip
-RUN unzip master.zip
-RUN mv examples-master guild-examples
-RUN rm master.zip
+RUN wget --quiet https://github.com/guildai/examples/archive/master.zip \
+    && unzip master.zip \
+    && mv examples-master guild-examples \
+    && rm master.zip
 
-CMD /bin/bash
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
* Have guild work in the Docker environment
    * For some reason it installs a broken virtualenv==20.0.0b2
    * Set LANG
    * Use python3 and pip3 since python2.7 had reached EOL.
* Increase reproducibility
    * Explicitly use Ubuntu 18
    * No apt-get upgrade
* Follow Docker best practices for Ubuntu base containers