### PR TITLE
Fix the incorrect output of tqdm while running remotely

### DIFF
--- a/guild/commands/watch_impl.py
+++ b/guild/commands/watch_impl.py
@@ -166,8 +166,8 @@ def _tail(run):
             out = f.read(TAIL_BUFFER)
             if out:
                 read += len(out)
-                sys.stdout.write(out)
-                sys.stdout.flush()
+                sys.stdout.buffer.write(out)
+                sys.stdout.buffer.flush()
             elif proc.is_running():
                 time.sleep(0.1)
             else:
@@ -192,13 +192,13 @@ def _print_output(run):
         out = f.read(TAIL_BUFFER)
         if not out:
             break
-        sys.stdout.write(out)
-        sys.stdout.flush()
+        sys.stdout.buffer.write(out)
+        sys.stdout.buffer.flush()
 
 
 def _try_open(path):
     try:
-        return open(path, "r")
+        return open(path, "rb")
     except (IOError, OSError) as e:
         if e.errno != 2:
             raise


### PR DESCRIPTION
Before applying this patch, navigate to the issue-resolution [72-guild-remote-output-not-visible-until-finished](https://github.com/guildai/issue-resolution/tree/master/72-guild-remote-output-not-visible-until-finished) and run

    guild run test use_tqdm=yes -r localhost

it would outputs something like below

      0%|          | 0/10 [00:00<?, ?it/s]
     10%|█         | 1/10 [00:00<00:01,  4.99it/s]s]
     20%|██        | 2/10 [00:00<00:01,  4.99it/s]t/s]
     30%|███       | 3/10 [00:00<00:01,  4.99it/s]9it/s]
     40%|████      | 4/10 [00:00<00:01,  4.99it/s].99it/s]
     50%|█████     | 5/10 [00:01<00:01,  4.99it/s] 4.99it/s]
     60%|██████    | 6/10 [00:01<00:00,  4.99it/s],  4.99it/s]
     70%|███████   | 7/10 [00:01<00:00,  4.99it/s]00,  4.99it/s]
     80%|████████  | 8/10 [00:01<00:00,  4.99it/s]0:00,  4.99it/s]
     90%|█████████ | 9/10 [00:01<00:00,  4.99it/s]<00:00,  4.99it/s]
    100%|██████████| 10/10 [00:02<00:00,  4.99it/s]
    100%|██████████| 10/10 [00:02<00:00,  4.99it/s]
    Traceback (most recent call last):
      File "/home/lyt/conda/envs/test/bin/guild", line 8, in <module>
        sys.exit(main())
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/main_bootstrap.py", line 40, in main
        guild.main.main()
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/main.py", line 33, in main
        _main()
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/main.py", line 40, in _main
        main_cmd.main(standalone_mode=False)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/external/click/core.py", line 759, in __call__
        return self.main(*args, **kwargs)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/external/click/core.py", line 714, in main
        rv = self.invoke(ctx)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/external/click/core.py", line 1132, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/external/click/core.py", line 951, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/external/click/core.py", line 552, in invoke
        return callback(*args, **kwargs)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/external/click/decorators.py", line 17, in new_func
        return f(get_current_context(), *args, **kwargs)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/click_util.py", line 141, in fn
        return fn0(*(args + (Args(**kw),)))
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/commands/watch.py", line 73, in watch
        watch_impl.main(args, ctx)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/commands/watch_impl.py", line 42, in main
        _watch_pid(args)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/commands/watch_impl.py", line 59, in _watch_pid
        _watch_run(run)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/commands/watch_impl.py", line 138, in _watch_run
        _tail(run)
      File "/home/lyt/conda/envs/test/lib/python3.7/site-packages/guild/commands/watch_impl.py", line 166, in _tail
        out = f.read(TAIL_BUFFER)
      File "/home/lyt/conda/envs/test/lib/python3.7/codecs.py", line 322, in decode
        (result, consumed) = self._buffer_decode(data, self.errors, final)
    UnicodeDecodeError: 'utf-8' codec can't decode byte 0x88 in position 0: invalid start byte

It shows incorrect outputs of tqdm and UnicodeDecodeError.

I found `guild cat` didn't suffer from this phenomenon. After applying
the logic behind guild/commands/cat_impl.py. It works like a charm!

I have tested this patch on Python 3.7 and Python 3.8.