### PR TITLE
In notebooks, record an interrupt as a terminated run

### DIFF
--- a/guild/ipy.py
+++ b/guild/ipy.py
@@ -379,6 +379,7 @@ def _run(op, flags, opts):
         exit_status = 1
         raise RunError(run, e)
     except KeyboardInterrupt as e:
+        log.warning("Run terminated by KeyboardInterrupt")
         exit_status = -1
         return run, None
     else:

--- a/guild/ipy.py
+++ b/guild/ipy.py
@@ -378,6 +378,9 @@ def _run(op, flags, opts):
     except Exception as e:
         exit_status = 1
         raise RunError(run, e)
+    except KeyboardInterrupt as e:
+        exit_status = -1
+        return run, None
     else:
         exit_status = 0
         return run, result


### PR DESCRIPTION
Currently when the kernel is interrupted (eg: a few epochs into a training run) the run status is set to *error*, an `UnboundLocalError` is raised with the following stack trace, and no run object is returned:
```
KeyboardInterrupt                         Traceback (most recent call last)
~/.virtualenvs/actrain/lib/python3.6/site-packages/guild/ipy.py in _run(op, flags, opts)
    354             with util.Chdir(run.path):
--> 355                 result = op(**flags)
    356     except Exception as e:
<timed exec> in train()
~/.virtualenvs/actrain/lib/python3.6/site-packages/allennlp/training/trainer.py in train(self)
    477             epoch_start_time = time.time()
--> 478             train_metrics = self._train_epoch(epoch)
    479 
~/.virtualenvs/actrain/lib/python3.6/site-packages/allennlp/training/trainer.py in _train_epoch(self, epoch)
    326 
--> 327             train_loss += loss.item()
    328 
KeyboardInterrupt: 
During handling of the above exception, another exception occurred:
UnboundLocalError                         Traceback (most recent call last)
<timed exec> in <module>
~/.virtualenvs/actrain/lib/python3.6/site-packages/guild/ipy.py in run(op, *args, **kw)
    278     flags = _init_flags(op, args, kw)
    279     run = _init_runner(op, flags, opts)
--> 280     return run()
    281 
    282 def _pop_opts(kw):
~/.virtualenvs/actrain/lib/python3.6/site-packages/guild/ipy.py in <lambda>()
    344 
    345 def _single_runner(op, flags, opts):
--> 346     return lambda: _run(op, flags, opts)
    347 
    348 def _run(op, flags, opts):
~/.virtualenvs/actrain/lib/python3.6/site-packages/guild/ipy.py in _run(op, flags, opts)
    361         return run, result
    362     finally:
--> 363         _finalize_run_attrs(run, exit_status)
    364 
    365 def _init_run():
UnboundLocalError: local variable 'exit_status' referenced before assignment
```

This PR captures the interrupt, sets the run status to *terminated* and returns the run object. No exceptions are raised.