### PR TITLE
In notebooks, during a run show the status as running

### DIFF
--- a/guild/run.py
+++ b/guild/run.py
@@ -143,7 +143,7 @@ class Run(object):
         if pid is None:
             exit_status = self.get("exit_status")
             if exit_status is None:
-                return "error"
+                return "running"
             elif exit_status == 0:
                 return "completed"
             elif exit_status < 0:


### PR DESCRIPTION
whilst a run is executing in a notebook, show the status as _running_ rather than _error_