### PR TITLE
fix error in creating lock file

### DIFF
--- a/guild/ipy.py
+++ b/guild/ipy.py
@@ -426,9 +426,8 @@ def _run(op, flag_vals, opts, extra_attrs=None):
     summary = _init_output_scalars(run, opts)
     try:
         with RunOutput(run, summary):
-            with util.Chdir(run.path):
-                _write_proc_lock(run)
-                result = op(**flag_vals)
+            _write_proc_lock(run)
+            result = op(**flag_vals)
     except KeyboardInterrupt as e:
         exit_status = exit_code.SIGTERM
         util.raise_from(RunTerminated(run, e), e)


### PR DESCRIPTION
This is the fix to the error I encountered while trying to use `guild` in a Jupyter notebook, as guided by [this reference](https://github.com/guildai/guildai/blob/master/examples/notebooks/get-started.ipynb)

In following code:
```
with RunOutput(run, summary):
    with util.Chdir(run.path):
        _write_proc_lock(run)
        result = op(**flag_vals)
```
`guild` will change directory to `<GUILD_HOME>/runs/<PID>` then try to create LOCK file in `<GUILD_HOME>/runs/<PID>/.guild/LOCK`. This fails as the full path for the LOCK file will now be `<GUILD_HOME>/runs/<PID>/<GUILD_HOME>/runs/<PID>/.guild/LOCK`. Simply removing the changing of directory fixes the problem (for me).