### PR TITLE
issue-242

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   - "%PYTHON%\\python.exe -m pip install -U setuptools"
   - "%PYTHON%\\python.exe -m pip install wheel"
   - "%PYTHON%\\python.exe -m pip install twine"
-  - "%PYTHON%\\python.exe -m pip install -r requirements-windows.txt"
+  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip install pandas"
 
 build: off

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-windows-curses

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ six>=1.10.0
 tabview>=1.4.3
 tensorboard>=2.0.0,<2.3.0
 virtualenv>=15.1.0
+windows-curses ; platform_system == "Windows"

--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,8 @@ guild_dist_basename = "guildai.dist-info"
 
 if platform.system() == "Windows":
     npm_cmd = "npm.cmd"
-    platform_requires = [
-        "windows-curses",
-    ]
 else:
     npm_cmd = "npm"
-    platform_requires = []
 
 def guild_dist_info():
     metadata = PathMetadata(".", guild_dist_basename)
@@ -229,7 +225,7 @@ setup(
     name="guildai",
     version=guild.__version__,
     description=PKG_INFO.get("Summary"),
-    install_requires=PKG_INFO.get_all("Requires-Dist") + platform_requires,
+    install_requires=PKG_INFO.get_all("Requires-Dist"),
     long_description=PKG_INFO.get_payload(),
     long_description_content_type="text/markdown",
     url=PKG_INFO.get("Home-page"),


### PR DESCRIPTION
Hi, sorry this ia bit vague, but I'm flying a little bit blind on this one as I'm not sure of the best way to test this.

The problem is that pypi lists `windows-curses` as a requirement in the meta-data regardless of platform.

I'm not sure why this is as from what I can tell, the [dist-info for the latest tag 0.7.0.post1](https://github.com/guildai/guildai/blob/0.7.0.post1/guildai.dist-info/METADATA) contains
```
Requires-Dist: Pillow>=5.0
Requires-Dist: PyYAML>=2.12
Requires-Dist: Werkzeug>=0.15
Requires-Dist: chardet>=3.0.4
Requires-Dist: daemonize>=2.4.7
Requires-Dist: filelock>=3.0.12
Requires-Dist: jinja2>=2.10
Requires-Dist: numpy>=1.16
Requires-Dist: pkginfo
Requires-Dist: scikit-learn>=0.19.1,<0.23.0
Requires-Dist: scikit-optimize>=0.7.1
Requires-Dist: setuptools>=40.6.3
Requires-Dist: six>=1.10.0
Requires-Dist: tabview>=1.4.3
Requires-Dist: tensorboard>=2.0.0,<2.3.0
Requires-Dist: virtualenv>=15.1.0
```
and the `install_requires` gets the list of packages from here as opposed to the `requirements.txt`.

However, `$ curl -sL https://pypi.org/pypi/guildai/json | jq '.info.requires_dist'`
produces 
```
[
  "Pillow (>=5.0)",
  "PyYAML (>=2.12)",
  "Werkzeug (>=0.15)",
  "chardet (>=3.0.4)",
  "daemonize (>=2.4.7)",
  "filelock (>=3.0.12)",
  "jinja2 (>=2.10)",
  "numpy (>=1.16)",
  "pkginfo",
  "scikit-learn (<0.23.0,>=0.19.1)",
  "scikit-optimize (>=0.7.1)",
  "setuptools (>=40.6.3)",
  "six (>=1.10.0)",
  "tabview (>=1.4.3)",
  "tensorboard (<2.3,>=1.15)",
  "virtualenv (>=15.1.0)",
  "windows-curses"
]
```

So, for some reason `windows-curses` is being added... I just don't know why

So, I have done the below... not really sure if it fixes it, but hopefully it can at least start a conversation.

---

According to [PEP-508](https://www.python.org/dev/peps/pep-0508/) platform-specific dependencies can be defined as part of the requirements.txt 

and this is in-line with [this advice](https://github.com/python-poetry/poetry/issues/3202#issuecomment-708347313)

I think this makes `requirements-windows.txt` redundant, so I've removed it, but please let me know if this will have some other effect that I'm not aware of.

Closes #242 