### PR TITLE
Fix looking for requirements.txt to install on remote (issue #292)

### DIFF
--- a/guild/package_main.py
+++ b/guild/package_main.py
@@ -321,10 +321,8 @@ def _pkg_keywords(pkgdef):
 
 
 def _pkg_install_requires(pkgdef):
-    if pkgdef.requires is None:
+    if pkgdef.requires is None or not pkgdef.requires:
         return _maybe_requirements_txt(pkgdef)
-    elif not pkgdef.requires:
-        return []
     else:
         return [
             _project_name(req) for req in pkgdef.requires if not _is_multi_arch_req(req)


### PR DESCRIPTION
It appears that the `pkgdef.requires` field is initialised as an empty list when not provided as part of the guild.yml file. This change ensures that if the `requires` field is not present, we still call `_maybe_requirements_txt` to look for the requirements.txt file to parse.

Closes #292