### PR TITLE
Access archived runs with ipy

### DIFF
--- a/guild/ipy.py
+++ b/guild/ipy.py
@@ -540,6 +540,7 @@ def _runs_cmd_args(
     digest=None,
     deleted=None,
     remote=None,
+    archive=None,
 ):
     operations = operations or ()
     labels = labels or ()
@@ -563,6 +564,7 @@ def _runs_cmd_args(
         filter_digest=digest,
         deleted=deleted,
         remote=remote,
+        archive=archive
     )
 
 


### PR DESCRIPTION
Easy way to access archived runs using `guild.ipy.runs`.

Usage:
```
runs = guild.runs(archive="/path/to/archived/runs")
```