### PR TITLE
Filtering tags based on a logical query

### DIFF
--- a/guild/commands/runs_support.py
+++ b/guild/commands/runs_support.py
@@ -19,7 +19,6 @@ import logging
 import sys
 
 import click
-from click.core import MultiCommand
 
 from guild import click_util
 

--- a/guild/commands/runs_support.py
+++ b/guild/commands/runs_support.py
@@ -19,6 +19,7 @@ import logging
 import sys
 
 import click
+from click.core import MultiCommand
 
 from guild import click_util
 
@@ -328,6 +329,12 @@ def common_filters(fn):
                 help="Filter runs with TAG.",
                 multiple=True,
                 autocompletion=ac_tag,
+            ),
+            click.Option(
+                ("--tags", "tags_query"),
+                metavar="QUERY",
+                help="Filter runs with query matching tags.",
+                multiple=False,
             ),
             click.Option(
                 ("-Fc", "--comment", "filter_comments"),

--- a/guild/ipy.py
+++ b/guild/ipy.py
@@ -574,8 +574,8 @@ def _format_runs(runs):
         "operation",
         "started",
         "status",
-        "label",
         "tags",
+        "label",
     )
     data = [_format_run(run, cols) for run in runs]
     return data, cols

--- a/guild/ipy.py
+++ b/guild/ipy.py
@@ -573,6 +573,7 @@ def _format_runs(runs):
         "started",
         "status",
         "label",
+        "tags",
     )
     data = [_format_run(run, cols) for run in runs]
     return data, cols
@@ -590,7 +591,7 @@ def _run_attr(run, name, fmt):
         return fmt[name]
     elif name in ("started", "stopped"):
         return _datetime(run.get(name))
-    elif name in ("label",):
+    elif name in ("label", "tags"):
         return run.get(name, "")
     elif name == "time":
         return _run_time(run)
@@ -686,7 +687,7 @@ def _run_flags_key(flag_vals):
 
 
 def _runs_compare(items):
-    core_cols = ["run", "operation", "started", "time", "status", "label"]
+    core_cols = ["run", "operation", "started", "time", "status", "label", "tags"]
     flag_cols = set()
     scalar_cols = set()
     data = []

--- a/guild/ipy.py
+++ b/guild/ipy.py
@@ -545,11 +545,16 @@ def _runs_cmd_args(
     operations = operations or ()
     labels = labels or ()
     tags = tags or ()
+    tags_query = ""
+    if isinstance(tags, str):
+        tags_query = tags
+        tags = ()
     comments = comments or ()
     return click_util.Args(
         filter_ops=operations,
         filter_labels=labels,
         filter_tags=tags,
+        tags_query=tags_query,
         filter_comments=comments,
         status_running=running,
         status_completed=completed,

--- a/guild/run_util.py
+++ b/guild/run_util.py
@@ -156,7 +156,7 @@ def format_run(run, index=None):
         "id": run.id,
         "index": _format_run_index(run, index),
         "label": run.get("label") or "",
-        "tags": ", ".join(run.get("run_params")["tags"]) or "",
+        "tags": run.get("tags") or "",
         "marked": format_attr(bool(run.get("marked"))),
         "model": run.opref.model_name,
         "op_name": run.opref.op_name,

--- a/guild/run_util.py
+++ b/guild/run_util.py
@@ -156,6 +156,7 @@ def format_run(run, index=None):
         "id": run.id,
         "index": _format_run_index(run, index),
         "label": run.get("label") or "",
+        "tags": ", ".join(run.get("run_params")["tags"]) or "",
         "marked": format_attr(bool(run.get("marked"))),
         "model": run.opref.model_name,
         "op_name": run.opref.op_name,


### PR DESCRIPTION
Originally posted in Issue #299 

Tags are very useful for differentiating between runs, but are currently not directly visible when displaying runs and no advanced filtering based on combinations of tags is possible. The idea is to add the following features:

1. Show tags in a separate column when runs are displayed.
2. A new filter (--tags QUERY) for filtering tags based on a logical query.

An example on how the filtering using a query works. A query (apple & not orange) | pear will be evaluated as ('apple' in run_tags & 'orange' not in run_tags) or 'pear' in run_tags internally. This allows for filtering runs on complex combinations of tags. None can be used to match runs without a tag (e.g., (apple | None)). Instead of the logical character | and &, the operators or and and can be used respectively (e.g., (apple and not orange) or pear).
