### PR TITLE
Fix saving multiple images in one cell

### DIFF
--- a/guild/plugins/nbexec.py
+++ b/guild/plugins/nbexec.py
@@ -576,6 +576,7 @@ def _iter_notebook_images(notebook):
                     output_pos,
                 )
                 yield filename, img_bytes
+            output_pos += 1
 
 
 def _nbconvert_html(notebook):


### PR DESCRIPTION
Problem: If there are multiple images plotted in one cell only the last image is saved (because the other images are overriden with the same file_name)

Solution: increase the (previously constant) `output_pos` variable so that every image gets a new filename