### PR TITLE
skip problematic run listing for python 3.6

### DIFF
--- a/guild/tests/flags-sub-commands.md
+++ b/guild/tests/flags-sub-commands.md
@@ -94,7 +94,7 @@ Run with modified flag vals.
 
 View the runs.
 
-    >>> run("guild runs")
+    >>> run("guild runs") # doctest: -PY36
     [1:...]  click-b-sub  ...  completed  b-sub-foo=77
     [2:...]  click-a      ...  completed  a-foo=55
     [3:...]  argparse-b   ...  completed  b-foo=33


### PR DESCRIPTION
Example failing CI run: https://app.circleci.com/pipelines/github/guildai/guildai/873/workflows/84f18e5e-e6c4-4b56-a58d-f44286a00ae6/jobs/6569

This is because we skip the earlier error test, and we skip that because of #390.