### PR TITLE
Revert python based autocomplete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,7 @@ env:
   DASK_SPEEDUP_THRESHOLD: 1.2
   # The following line is a temporary workaround for this issue: https://github.com/pypa/setuptools/issues/2230
   SETUPTOOLS_USE_DISTUTILS: stdlib
-  # don't set this. We are using bash as the shell, and we want to verify
-  #   that it gets detected properly
-  # GUILD_SHELL: bash
+  GUILD_SHELL: bash
 
 jobs:
   lint:

--- a/guild/click_util.py
+++ b/guild/click_util.py
@@ -26,7 +26,7 @@ from click import shell_completion
 
 import guild
 from .util import natsorted
-from .commands.completion_impl import _current_shell
+from .commands.completion_impl import _current_shell_supports_directives
 
 CMD_SPLIT_P = re.compile(r", ?")
 
@@ -326,6 +326,11 @@ def _maybe_render_doc(s, vars):
     return fn.__doc__
 
 
+# we use shell functions where possible to provide listing. This is for the sake
+#    of speed as well as making the behavior as close as possible to the user's
+#    native shell. However, supporting new shells means implementing behavior for
+#    our !! directives. We provide native Python implementation as a fallback where
+#    we have not yet implemented handling for our directives.
 def _list_dir(dir, incomplete, filters=None, ext=None):
     if ext:
         ext = ["." + _ if not _.startswith(".") else _ for _ in ext]
@@ -352,48 +357,72 @@ def _list_dir(dir, incomplete, filters=None, ext=None):
 
 
 def completion_filename(ext=None, incomplete=None):
-    if os.getenv("_GUILD_COMPLETE", "") != "":
+    if os.getenv("_GUILD_COMPLETE") == "complete":
+        if _current_shell_supports_directives():
+            return _compgen_filenames("file", ext)
         return _list_dir(os.getcwd(), incomplete, ext=ext)
     else:
         return []
 
 
-def completion_dir(_=None, __=None, incomplete=None):
-    if os.getenv("_GUILD_COMPLETE", "") != "":
+# we have to have the weird placeholders here because we call this directly as
+#   an autocomplete function, while also sometimes using it as a helper function
+#   for another autocomplete function
+def completion_dir(_, __, incomplete=None):
+    if os.getenv("_GUILD_COMPLETE") == "complete":
+        if _current_shell_supports_directives():
+            return ["!!dir"]
         return _list_dir(os.getcwd(), incomplete, filters=[os.path.isdir])
     else:
         return []
 
 
 def completion_opnames(names):
-    if os.getenv("_GUILD_COMPLETE", "") != "":
-        if _current_shell() == "bash":
+    if os.getenv("_GUILD_COMPLETE") == "complete":
+        if _current_shell_supports_directives():
             names = ["!!no-colon-wordbreak"] + names
         return names
     else:
         return []
 
 
+def _compgen_filenames(type, ext):
+    if not ext:
+        return ["!!%s:*" % type]
+    return ["!!%s:*.@(%s)" % (type, "|".join(ext))]
+
+
 def completion_nospace():
-    if os.getenv("_GUILD_COMPLETE", "") != "" and _current_shell() == "bash":
+    if (
+        os.getenv("_GUILD_COMPLETE") == "complete"
+        and _current_shell_supports_directives()
+    ):
         return ["!!nospace"]
-    else:
-        return []
+    return []
 
 
 def completion_batchfile(ext=None, incomplete=None):
     incomplete = incomplete or ""
-    if os.getenv("_GUILD_COMPLETE", "") != "":
+    if os.getenv("_GUILD_COMPLETE") == "complete":
+        if _current_shell_supports_directives():
+            return _compgen_filenames("batchfile", ext)
         return [
             "@" + str(item)
             for item in _list_dir(os.getcwd(), incomplete.replace("@", ""), ext=ext)
         ]
+
     else:
         return []
 
 
 def completion_command(filter=None, incomplete=None):
-    if os.getenv("_GUILD_COMPLETE", "") != "":
+    if os.getenv("_GUILD_COMPLETE") == "complete":
+        if _current_shell_supports_directives():
+            if filter:
+                return ["!!command:%s" % filter]
+            else:
+                return ["!!command"]
+
         # TODO: how should we handle this on windows? call out to bash explicitly? better
         #    to avoid explicitly calling sh.
         available_commands = subprocess.check_output(
@@ -420,7 +449,12 @@ def completion_command(filter=None, incomplete=None):
 
 
 def completion_run_dirpath(run_dir, all=False, incomplete=None):
-    if os.getenv("_GUILD_COMPLETE", "") != "":
+    if os.getenv("_GUILD_COMPLETE") == "complete":
+        if _current_shell_supports_directives():
+            if all:
+                return ["!!allrundirs:%s" % run_dir]
+            else:
+                return ["!!rundirs:%s" % run_dir]
         filters = [os.path.isdir, lambda x: os.path.isdir(os.path.join(x, ".guild"))]
         if all:
             filters.pop()
@@ -430,7 +464,9 @@ def completion_run_dirpath(run_dir, all=False, incomplete=None):
 
 
 def completion_run_filepath(run_dir, incomplete):
-    if os.getenv("_GUILD_COMPLETE", "") != "":
+    if os.getenv("_GUILD_COMPLETE") == "complete":
+        if _current_shell_supports_directives():
+            return ["!!runfiles:%s" % run_dir]
         return _list_dir(run_dir, incomplete)
     else:
         return []

--- a/guild/click_util.py
+++ b/guild/click_util.py
@@ -26,7 +26,7 @@ from click import shell_completion
 
 import guild
 from .util import natsorted
-from .commands.completion_impl import current_shell_supports_directives
+from .commands.completion_impl import current_shell_supports_directives, _current_shell
 
 CMD_SPLIT_P = re.compile(r", ?")
 
@@ -390,7 +390,13 @@ def _compgen_filenames(type, ext):
 
 
 def completion_nospace():
-    if os.getenv("_GUILD_COMPLETE") and current_shell_supports_directives():
+    # TODO: zsh supports this directive, but not the others.
+    # We should add proper support for all of them at some point.
+    if (
+        os.getenv("_GUILD_COMPLETE")
+        and current_shell_supports_directives()
+        or _current_shell() == "zsh"
+    ):
         return ["!!nospace"]
     return []
 

--- a/guild/click_util.py
+++ b/guild/click_util.py
@@ -26,7 +26,7 @@ from click import shell_completion
 
 import guild
 from .util import natsorted
-from .commands.completion_impl import _current_shell_supports_directives
+from .commands.completion_impl import current_shell_supports_directives
 
 CMD_SPLIT_P = re.compile(r", ?")
 
@@ -357,33 +357,30 @@ def _list_dir(dir, incomplete, filters=None, ext=None):
 
 
 def completion_filename(ext=None, incomplete=None):
-    if os.getenv("_GUILD_COMPLETE") == "complete":
-        if _current_shell_supports_directives():
+    if os.getenv("_GUILD_COMPLETE"):
+        if current_shell_supports_directives():
             return _compgen_filenames("file", ext)
         return _list_dir(os.getcwd(), incomplete, ext=ext)
-    else:
-        return []
+    return []
 
 
 # we have to have the weird placeholders here because we call this directly as
 #   an autocomplete function, while also sometimes using it as a helper function
 #   for another autocomplete function
 def completion_dir(_, __, incomplete=None):
-    if os.getenv("_GUILD_COMPLETE") == "complete":
-        if _current_shell_supports_directives():
+    if os.getenv("_GUILD_COMPLETE"):
+        if current_shell_supports_directives():
             return ["!!dir"]
         return _list_dir(os.getcwd(), incomplete, filters=[os.path.isdir])
-    else:
-        return []
+    return []
 
 
 def completion_opnames(names):
-    if os.getenv("_GUILD_COMPLETE") == "complete":
-        if _current_shell_supports_directives():
+    if os.getenv("_GUILD_COMPLETE"):
+        if current_shell_supports_directives():
             names = ["!!no-colon-wordbreak"] + names
         return names
-    else:
-        return []
+    return []
 
 
 def _compgen_filenames(type, ext):
@@ -393,35 +390,29 @@ def _compgen_filenames(type, ext):
 
 
 def completion_nospace():
-    if (
-        os.getenv("_GUILD_COMPLETE") == "complete"
-        and _current_shell_supports_directives()
-    ):
+    if os.getenv("_GUILD_COMPLETE") and current_shell_supports_directives():
         return ["!!nospace"]
     return []
 
 
 def completion_batchfile(ext=None, incomplete=None):
     incomplete = incomplete or ""
-    if os.getenv("_GUILD_COMPLETE") == "complete":
-        if _current_shell_supports_directives():
+    if os.getenv("_GUILD_COMPLETE"):
+        if current_shell_supports_directives():
             return _compgen_filenames("batchfile", ext)
         return [
             "@" + str(item)
             for item in _list_dir(os.getcwd(), incomplete.replace("@", ""), ext=ext)
         ]
-
-    else:
-        return []
+    return []
 
 
 def completion_command(filter=None, incomplete=None):
-    if os.getenv("_GUILD_COMPLETE") == "complete":
-        if _current_shell_supports_directives():
+    if os.getenv("_GUILD_COMPLETE"):
+        if current_shell_supports_directives():
             if filter:
                 return ["!!command:%s" % filter]
-            else:
-                return ["!!command"]
+            return ["!!command"]
 
         # TODO: how should we handle this on windows? call out to bash explicitly? better
         #    to avoid explicitly calling sh.
@@ -444,32 +435,28 @@ def completion_command(filter=None, incomplete=None):
                 cmd for cmd in available_commands if cmd.startswith(incomplete)
             ]
         return available_commands
-    else:
-        return []
+    return []
 
 
 def completion_run_dirpath(run_dir, all=False, incomplete=None):
-    if os.getenv("_GUILD_COMPLETE") == "complete":
-        if _current_shell_supports_directives():
+    if os.getenv("_GUILD_COMPLETE"):
+        if current_shell_supports_directives():
             if all:
                 return ["!!allrundirs:%s" % run_dir]
-            else:
-                return ["!!rundirs:%s" % run_dir]
+            return ["!!rundirs:%s" % run_dir]
         filters = [os.path.isdir, lambda x: os.path.isdir(os.path.join(x, ".guild"))]
         if all:
             filters.pop()
         return _list_dir(dir=run_dir, incomplete=incomplete, filters=filters)
-    else:
-        return []
+    return []
 
 
 def completion_run_filepath(run_dir, incomplete):
-    if os.getenv("_GUILD_COMPLETE") == "complete":
-        if _current_shell_supports_directives():
+    if os.getenv("_GUILD_COMPLETE"):
+        if current_shell_supports_directives():
             return ["!!runfiles:%s" % run_dir]
         return _list_dir(run_dir, incomplete)
-    else:
-        return []
+    return []
 
 
 def completion_safe_apply(ctx, f, args):

--- a/guild/commands/completion_impl.py
+++ b/guild/commands/completion_impl.py
@@ -61,7 +61,9 @@ def _current_shell():
 
 def current_shell_supports_directives():
     # TODO: we should maybe register this support in a more dynamic way instead of hard-coding it
-    return _current_shell() in {"bash", "zsh"}
+    return _current_shell() in {
+        "bash",
+    }
 
 
 def _completion_script(shell):

--- a/guild/commands/completion_impl.py
+++ b/guild/commands/completion_impl.py
@@ -45,6 +45,7 @@ def main(args):
 def _current_shell():
     parent_shell = os.getenv("GUILD_SHELL")
     known_shells = {"bash", "zsh", "fish", "dash", "sh"}
+
     if not parent_shell:
         parent_shell = os.path.basename(psutil.Process().parent().exe())
     if parent_shell not in known_shells:
@@ -58,7 +59,7 @@ def _current_shell():
     return parent_shell
 
 
-def _current_shell_supports_directives():
+def current_shell_supports_directives():
     # TODO: we should maybe register this support in a more dynamic way instead of hard-coding it
     return _current_shell() in {"bash", "zsh"}
 

--- a/guild/commands/completion_impl.py
+++ b/guild/commands/completion_impl.py
@@ -58,6 +58,11 @@ def _current_shell():
     return parent_shell
 
 
+def _current_shell_supports_directives():
+    # TODO: we should maybe register this support in a more dynamic way instead of hard-coding it
+    return _current_shell() in {"bash", "zsh"}
+
+
 def _completion_script(shell):
     path = os.path.join(_completions_dir(), "%s-guild" % shell)
     if log.getEffectiveLevel() <= logging.DEBUG:

--- a/guild/commands/help.py
+++ b/guild/commands/help.py
@@ -23,7 +23,7 @@ def _ac_path_or_package(_, __, incomplete):
     packages = [pkg.project_name for pkg in packages_impl.packages(False)]
     return sorted(
         [pkg for pkg in packages if pkg.startswith(incomplete)]
-    ) + click_util.completion_dir(incomplete=incomplete)
+    ) + click_util.completion_dir(_, __, incomplete=incomplete)
 
 
 @click.command()

--- a/guild/commands/init.py
+++ b/guild/commands/init.py
@@ -19,7 +19,7 @@ from guild import click_util
 
 def _ac_python(_, __, incomplete):
     filter = r"^python[^-]*(?!-config)$"
-    if click_util._current_shell_supports_directives():
+    if click_util.current_shell_supports_directives():
         # shell matching is a bit different than regex
         filter = "python*[^-config]"
     return click_util.completion_command(filter=filter, incomplete=incomplete)

--- a/guild/commands/init.py
+++ b/guild/commands/init.py
@@ -18,9 +18,11 @@ from guild import click_util
 
 
 def _ac_python(_, __, incomplete):
-    return click_util.completion_command(
-        filter="^python[^-]*(?!-config)$", incomplete=incomplete
-    )
+    filter = r"^python[^-]*(?!-config)$"
+    if click_util._current_shell_supports_directives():
+        # shell matching is a bit different than regex
+        filter = "python*[^-config]"
+    return click_util.completion_command(filter=filter, incomplete=incomplete)
 
 
 def _ac_guild_version_or_path(ctx, _, incomplete):

--- a/guild/commands/init.py
+++ b/guild/commands/init.py
@@ -44,7 +44,7 @@ def _guild_versions(ctx):
 
 
 def _ac_guild_home(_, __, incomplete):
-    return click_util.completion_dir(incomplete=incomplete)
+    return click_util.completion_dir(_, __, incomplete=incomplete)
 
 
 def _ac_requirement(_, __, incomplete):
@@ -52,7 +52,7 @@ def _ac_requirement(_, __, incomplete):
 
 
 def _ac_path(_, __, incomplete):
-    return click_util.completion_dir(incomplete=incomplete)
+    return click_util.completion_dir(_, __, incomplete=incomplete)
 
 
 @click.command()

--- a/guild/commands/run.py
+++ b/guild/commands/run.py
@@ -41,9 +41,10 @@ def _ac_operations(ctx, _, incomplete):
             return [op["fullname"] for op in operations_impl.filtered_ops(ops_args)]
 
     ops = click_util.completion_safe_apply(ctx, f, [])
+
     if not ops:
         return []
-    names = [op for op in ops if op.startswith(incomplete)]
+    names = [op for op in ops if (not incomplete or op.startswith(incomplete))]
     return click_util.completion_opnames(names)
 
 

--- a/guild/commands/run.py
+++ b/guild/commands/run.py
@@ -151,8 +151,8 @@ def _ac_flag_choices(incomplete, opdef):
 
 def _maybe_filename_type(flagdef):
     assert flagdef
-    if flagdef.type and flagdef.type not in ("int", "float", "number", "boolean"):
-        return True
+    if flagdef.type:
+        return flagdef.type not in {"int", "float", "number", "boolean"}
     parsed_type = type(flagdef.default)
     if parsed_type not in {int, float, bool}:
         return True

--- a/guild/commands/run.py
+++ b/guild/commands/run.py
@@ -15,6 +15,7 @@
 import click
 
 from guild import click_util
+from .completion_impl import _current_shell
 
 from . import remote_support
 
@@ -67,41 +68,30 @@ def _ac_flag(ctx, _, incomplete):
     flags_are_complete_sets = all("=" in item for item in flags)
     if flags_are_complete_sets:
         for f in run_args.flags:
-            name, value = f.split("=")
+            parts = f.split("=")
+            name = parts[0]
+            if len(parts) == 1:
+                value = ""
+            else:
+                value = parts[1]
             flags.extend([name, "=", value])
     else:
         flags = run_args.flags
-
-    if incomplete and incomplete[-1] == "=":
-        incomplete = incomplete[:-1]
-        flags.append(incomplete)
 
     # completed flags come in 3's - the name, the equals sign, the value.
     # If we have a even division, we have no incomplete flag. Otherwise, take
     # the end element as the incomplete flag.
     if flags and len(flags) % 3:
-        incomplete = flags[-1]
+        incomplete = "".join(flags[: -len(flags) % 3])
 
-    if (incomplete and "=" in incomplete) or (
-        any(incomplete == flag.name for flag in opdef.flags)
-        and sum([flag.name.startswith(incomplete) for flag in opdef.flags]) == 1
-    ):
-        if "=" not in incomplete:
-            incomplete += "="
+    if incomplete and "=" in incomplete:
         return _ac_flag_choices(incomplete, opdef)
-
-    existing_text = " ".join(["".join(flag_group) for flag_group in flags[::3]])
-    existing_text = ""
 
     # every third element is a flag name. The value may or may not be there for the last flag.
     used_flags = flags[::3]
     unused_flags = sorted([f.name for f in opdef.flags if f.name not in used_flags])
     flags_ac = [f for f in unused_flags if (not incomplete or f.startswith(incomplete))]
-    names = click_util.completion_opnames(["%s=" % f for f in flags_ac])
-    if existing_text:
-        names = [existing_text + " " + name for name in names]
-    result = names + click_util.completion_nospace()
-
+    result = ["%s=" % f for f in flags_ac] + click_util.completion_nospace()
     return result
 
 
@@ -132,15 +122,41 @@ def _ac_opdef(opspec):
 def _ac_flag_choices(incomplete, opdef):
     flag_name, flag_val_incomplete = incomplete.split("=", 1)
     flagdef = opdef.get_flagdef(flag_name)
+
     if not flagdef or (not flagdef.choices and _maybe_filename_type(flagdef)):
-        return click_util.completion_filename()
+        values = click_util.completion_filename()
+        if _current_shell() == "bash":
+            return values
+        values = [flag_name + "=" + value for value in values]
+        return values
     choices = _flagdef_choices(flagdef)
-    return [val for val in choices if val.startswith(flag_val_incomplete)]
+    values = [
+        val
+        for val in choices
+        if (not flag_val_incomplete or val.startswith(flag_val_incomplete))
+    ]
+    if _current_shell() == "bash":
+        # bash wants only the completed value here, whereas zsh wants the flag name also
+        return values
+    else:
+        values = [flag_name + "=" + value for value in values]
+        if not values:
+            values = (
+                [flag_name + "=" + flag_val_incomplete]
+                if flag_val_incomplete
+                else [flag_name + "="] + click_util.completion_nospace()
+            )
+    return values
 
 
 def _maybe_filename_type(flagdef):
     assert flagdef
-    return flagdef.type not in ("int", "float", "number", "boolean")
+    if flagdef.type and flagdef.type not in ("int", "float", "number", "boolean"):
+        return True
+    parsed_type = type(flagdef.default)
+    if parsed_type not in {int, float, bool}:
+        return True
+    return False
 
 
 def _flagdef_choices(flagdef):

--- a/guild/commands/runs_diff.py
+++ b/guild/commands/runs_diff.py
@@ -78,7 +78,7 @@ def _run_to_diff(ctx):
 
 
 def _ac_dir(_, __, incomplete):
-    return click_util.completion_dir(incomplete=incomplete)
+    return click_util.completion_dir(_, __, incomplete=incomplete)
 
 
 def diff_params(fn):

--- a/guild/commands/runs_export.py
+++ b/guild/commands/runs_export.py
@@ -20,7 +20,7 @@ from . import runs_support
 
 def _ac_location(_, __, incomplete):
     return click_util.completion_dir(
-        incomplete=incomplete
+        _, __, incomplete=incomplete
     ) + click_util.completion_filename(ext=["zip"], incomplete=incomplete)
 
 

--- a/guild/commands/runs_import.py
+++ b/guild/commands/runs_import.py
@@ -20,7 +20,7 @@ from . import runs_support
 
 def _ac_archive(_, __, incomplete):
     return click_util.completion_dir(
-        incomplete=incomplete
+        _, __, incomplete=incomplete
     ) + click_util.completion_filename(ext=["zip"], incomplete=incomplete)
 
 

--- a/guild/commands/runs_support.py
+++ b/guild/commands/runs_support.py
@@ -112,7 +112,7 @@ def ac_digest(ctx, _, incomplete):
 
 def ac_archive(_, __, incomplete):
     return click_util.completion_dir(
-        incomplete=incomplete
+        _, __, incomplete=incomplete
     ) + click_util.completion_filename(ext=["zip"], incomplete=incomplete)
 
 

--- a/guild/completions/bash-guild
+++ b/guild/completions/bash-guild
@@ -1,39 +1,100 @@
 #-*-shell-script-*-
-_guild_completion() {
-    local IFS=$'\n'
-    local response
 
-    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _GUILD_COMPLETE=bash_complete $1)
+# Extract from bash_completion
+declare -F __reassemble_comp_words_by_ref >/dev/null ||
+__reassemble_comp_words_by_ref() {
+    local exclude i j line ref
+    if [[ $1 ]]; then
+        exclude="[${1//[^$COMP_WORDBREAKS]/}]"
+    fi
+
+    printf -v "$3" %s "$COMP_CWORD"
+    if [[ -v exclude ]]; then
+        line=$COMP_LINE
+        for ((i = 0, j = 0; i < ${#COMP_WORDS[@]}; i++, j++)); do
+            while [[ $i -gt 0 && ${COMP_WORDS[i]} == +($exclude) ]]; do
+                [[ $line != [[:blank:]]* ]] && ((j >= 2)) && ((j--))
+                ref="$2[$j]"
+                printf -v "$ref" %s "${!ref-}${COMP_WORDS[i]}"
+                ((i == COMP_CWORD)) && printf -v "$3" %s "$j"
+                line=${line#*"${COMP_WORDS[i]}"}
+                [[ $line == [[:blank:]]* ]] && ((j++))
+                ((i < ${#COMP_WORDS[@]} - 1)) && ((i++)) || break 2
+            done
+            ref="$2[$j]"
+            printf -v "$ref" %s "${!ref-}${COMP_WORDS[i]}"
+            line=${line#*"${COMP_WORDS[i]}"}
+            ((i == COMP_CWORD)) && printf -v "$3" %s "$j"
+        done
+        ((i == COMP_CWORD)) && printf -v "$3" %s "$j"
+    else
+        for i in "${!COMP_WORDS[@]}"; do
+            printf -v "$2[i]" %s "${COMP_WORDS[i]}"
+        done
+    fi
+}
+
+__apply_alt_cwd() {
+    # Applies alt current working directory to COMPREPLY.
+    for i in "${!COMPREPLY[@]}"; do
+        if [[ -d $1/${COMPREPLY[i]} ]]; then
+            COMPREPLY[i]+=/
+            compopt -o nospace
+        fi
+    done
+}
+
+_guild_completion() {
+    local cword words
+    __reassemble_comp_words_by_ref "=:" words cword
+
+    # Use guild to generate comp reply - includes possible directives
+    # that are processed later.
+    local IFS=$'\n'
+    local reply=($(COMP_WORDS="${words[*]}" \
+                   COMP_CWORD=$cword \
+                   _GUILD_COMPLETE=complete $1))
 
     COMP_WORDBREAKS='"'"'"'><=;|&(: '  # Reset as can be modified below.
-    for completion in $response; do
-        IFS=',' read type value <<< "$completion"
-        if [ "$value" = "!!nospace" ]; then
+    COMPREPLY=()
+    local item alt_cwd
+    for item in "${reply[@]}"; do
+        if [ "${item:0:7}" = '!!file:' ]; then
+            COMPREPLY+=($(compgen -f -X '!'"${item:7}" -o plusdirs -- $2))
+            compopt -o filenames
+        elif [ "${item:0:7}" = '!!dir' ]; then
+            COMPREPLY+=($(compgen -d -- $2))
+            compopt -o filenames
+        elif [ "${item:0:12}" = '!!batchfile:' ]; then
+            COMPREPLY+=($(compgen -f -X '!'"${item:12}" -P @ -o plusdirs -- ${2:1}))
+            compopt -o filenames
+        elif [ "${item:0:10}" = '!!rundirs:' ]; then
+            alt_cwd="${item:10}"
+            COMPREPLY+=($(cd "$alt_cwd" && compgen -d -X .guild -- $2))
+            __apply_alt_cwd "$alt_cwd"
+        elif [ "${item:0:13}" = '!!allrundirs:' ]; then
+            alt_cwd="${item:13}"
+            COMPREPLY+=($(cd "$alt_cwd" && compgen -d -- $2))
+            __apply_alt_cwd "$alt_cwd"
+        elif [ "${item:0:11}" = '!!runfiles:' ]; then
+            alt_cwd="${item:11}"
+            COMPREPLY+=($(cd "$alt_cwd" && compgen -f -X .guild -- $2))
+            __apply_alt_cwd "$alt_cwd"
+        elif [ "$item" = "!!nospace" ]; then
             compopt -o nospace
-            continue
-        elif [ "$value" = "!!no-colon-wordbreak" ]; then
+        elif [ "${item:0:10}" = "!!command:" ]; then
+            COMPREPLY+=($(compgen -c -X '!'"${item:10}" -- $2))
+        elif [ "$item" = "!!command" ]; then
+            COMPREPLY+=($(compgen -c -- $2))
+        elif [ "$item" = "!!no-colon-wordbreak" ]; then
             # Dangerous as this effects other completions. The damage
             # is mitigated by resetting COMP_WORDBREAKS above but this
             # is still not ideal.
             COMP_WORDBREAKS='"'"'"'><=;|&( '
-            continue
-        fi
-        if [[ $type == 'dir' ]]; then
-            COMPREPLY=()
-            compopt -o dirnames
-        elif [[ $type == 'file' ]]; then
-            COMPREPLY=()
-            compopt -o default
-        elif [[ $type == 'plain' ]]; then
-            COMPREPLY+=($value)
+        else
+            COMPREPLY+=($item)
         fi
     done
 
-    return 0
-}
-
-_guild_completion_setup() {
-    complete -o nosort -F _guild_completion guild
-}
-
-_guild_completion_setup;
+} && complete -o nosort -F _guild_completion guild 2> /dev/null \
+  || complete -F _guild_completion guild

--- a/guild/completions/bash-guild
+++ b/guild/completions/bash-guild
@@ -53,12 +53,16 @@ _guild_completion() {
     local IFS=$'\n'
     local reply=($(COMP_WORDS="${words[*]}" \
                    COMP_CWORD=$cword \
-                   _GUILD_COMPLETE=complete $1))
+                   _GUILD_COMPLETE=bash_complete $1))
 
     COMP_WORDBREAKS='"'"'"'><=;|&(: '  # Reset as can be modified below.
     COMPREPLY=()
     local item alt_cwd
     for item in "${reply[@]}"; do
+        # Click 8 introduced a notion of type here. We strip it off before our normal directive handling
+        if [ "${item:0:6}" = "plain," ]; then
+            item="${item:6}"
+        fi
         if [ "${item:0:7}" = '!!file:' ]; then
             COMPREPLY+=($(compgen -f -X '!'"${item:7}" -o plusdirs -- $2))
             compopt -o filenames
@@ -91,6 +95,7 @@ _guild_completion() {
             # is mitigated by resetting COMP_WORDBREAKS above but this
             # is still not ideal.
             COMP_WORDBREAKS='"'"'"'><=;|&( '
+            continue
         else
             COMPREPLY+=($item)
         fi

--- a/guild/completions/zsh-guild
+++ b/guild/completions/zsh-guild
@@ -5,12 +5,15 @@ _guild_completion() {
     local -a completions
     local -a completions_with_descriptions
     local -a response
+    nospace_suffix=" "
     (( ! $+commands[guild] )) && return 1
 
     response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _GUILD_COMPLETE=zsh_complete guild)}")
 
     for type key descr in ${response}; do
-        if [[ "$type" == "plain" ]]; then
+        if [[ "$key" == "!!nospace" ]]; then
+            nospace_suffix=""
+        elif [[ "$type" == "plain" ]]; then
             if [[ "$descr" == "_" ]]; then
                 completions+=("$key")
             else
@@ -28,7 +31,7 @@ _guild_completion() {
     fi
 
     if [ -n "$completions" ]; then
-        compadd -U -V unsorted -a completions
+        compadd -S "$nospace_suffix" -U -V unsorted -a completions
     fi
 }
 

--- a/guild/plugins/dask_scheduler_main.py
+++ b/guild/plugins/dask_scheduler_main.py
@@ -273,16 +273,14 @@ def _decode_dask_resources(encoded, quiet=False):
     from guild import op_util
 
     args = util.shlex_split(encoded)
-    try:
-        return op_util.parse_flag_assigns(args)
-    except op_util.ArgValueError:
-        if not quiet:
-            log.warning(
-                "Ignoring invalid dask resources spec %r: parts must be in "
-                "format KEY=VAL",
-                encoded,
-            )
-        return {}
+    flags, errors = op_util.parse_flag_assigns(args)
+    if errors and not quiet:
+        log.warning(
+            "Ignoring invalid dask resources spec %r: parts must be in "
+            "format KEY=VAL",
+            encoded,
+        )
+    return flags
 
 
 def _log_scheduling(run, resources):

--- a/guild/tests/autocomplete.md
+++ b/guild/tests/autocomplete.md
@@ -9,8 +9,8 @@ Helper functions:
     ...             def f(**kw):
     ...                 with Env({"_GUILD_COMPLETE": "complete"}):
     ...                     completion_result = param.shell_complete(param, "")
-    ...                     if completion_result and hasattr(completion_result, "value"):
-    ...                         completion_result = [_.value for _ in completion_result]
+    ...                     completion_result = [_.value if hasattr(_, "value") else _ for _ in completion_result]
+    ...                     return completion_result
     ...             return f
     ...     assert False, (param_name, cmd.params)
 
@@ -37,6 +37,7 @@ markdown and text files.
     additional-deps
     anonymous-models
     api
+    api-cmd
     autocomplete
     ...
     var
@@ -101,7 +102,7 @@ A helper to show completions:
     ...     empty = True
     ...     with Env({"_GUILD_COMPLETE": "complete"}):
     ...         for val in ac_f(ctx, incomplete):
-    ...             print(val)
+    ...             print(val.value if hasattr(val, "value") else val)
     ...             empty = False
     ...     if empty:
     ...         print("<empty>")
@@ -244,9 +245,16 @@ Path completion for `--sourcecode` option.
 
     >>> from guild.commands import diff
 
-### `runs` arg
+### `run` arg
 
-    >>> cmd_ac(diff.diff, "runs", [])
+    >>> cmd_ac(diff.diff, "run", [])
+    aaa
+    bbb
+    ccc
+
+### `other_run` arg
+
+    >>> cmd_ac(diff.diff, "other_run", [])
     aaa
     bbb
     ccc
@@ -521,7 +529,7 @@ The first param to export is the export location.
 Locations may be directories or zip files.
 
     >>> with Env({"_GUILD_COMPLETE": "complete"}):
-    ...     runs_export.export_runs.params[0].shell_complete(None, "")
+    ...     [_.value for _ in runs_export.export_runs.params[0].shell_complete(None, "")]
     ['!!dir', '!!file:*.@(zip)']
 
 ## `help`
@@ -546,7 +554,7 @@ directories.
 The archive location for import is a directory.
 
     >>> with Env({"_GUILD_COMPLETE": "complete"}):
-    ...     runs_import.import_runs.params[0].shell_complete(None, "")
+    ...     [_.value for _ in runs_import.import_runs.params[0].shell_complete(None, "")]
     ['!!dir', '!!file:*.@(zip)']
 
 ## `init`
@@ -561,7 +569,7 @@ Helper to print completions.
     ...     ctx.parent = main.main.make_context("", ["-H", project.guild_home])
     ...     with Env({"_GUILD_COMPLETE": "complete"}):
     ...         for val in f(ctx, None, incomplete):
-    ...             print(val)
+    ...             print(val.value if hasattr(val, "value") else val)
 
 Python versions:
 


### PR DESCRIPTION
@gar1t and I decided that the python-based autocompletion was not working well enough, and would require too much work to get right. We're going back to the old way, but we're keeping the python-based autocompletion as a fallback for shells where we have not yet implemented handling of our directives with native shell functions. This rolls back some of the work in #384, but mostly keeps it for the sake of shells that we don't yet fully support. The goal is to have bash and zsh fully implemented, while fish and possibly others remain semi-supported with the python completion.