### PR TITLE
Change how `{python_exe}` resolves from activated venvs

### DIFF
--- a/guild/config.py
+++ b/guild/config.py
@@ -262,8 +262,6 @@ def python_exe():
     return _find_apply(
         [
             _guild_python_exe,
-            _virtualenv_python_exe,
-            _conda_python_exe,
             _sys_executable,
         ]
     )


### PR DESCRIPTION
This patch makes guild prefer using `sys.executable` over `VIRTUAL_ENV/bin/python` or `CONDA_PREFIX/bin/python` to resolve `{python_exe}` when evaluating templated `exec` strings.  

Reasoning:

-  If user is launching a guild call from a shell with an activated env where guild is installed, this is no change. In this scenario, `sys.executable` is the same as `VIRTUAL_ENV/bin/python`

- If user is launching the guild call from a shell with an activated env where guild is *not* installed, (and the guild executable is installed elsewhere and invoked with an absolute path or on the PATH otherwise, e.g., via pipx or a symlink), then `{python_exe}` in an exec string will resolve to the wrong python without this patch.

- Python docs explicitly warn that `VIRTUAL_ENV` should not be used to infer the python location.