### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/package/docker/guildai/Dockerfile
+++ b/package/docker/guildai/Dockerfile
@@ -5,10 +5,10 @@ ENV LANG C.UTF-8
 
 RUN apt-get update --assume-yes \
     && apt-get install --assume-yes \
-        wget \
-        unzip \
-        python3 \
-        python3-pip \
+        wget=1.19.* \ 
+        unzip=6.0-* \ 
+        python3=3.6.* \ 
+        python3-pip=9.0.* \ 
     && update-alternatives --install /usr/bin/python python /usr/bin/python3 2 \
     && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 2 \
     &&  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hi!
The Dockerfile placed at "package/docker/guildai/Dockerfile" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved using the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance