### PR TITLE
Pins remote

### DIFF
--- a/guild/remotes/pins.py
+++ b/guild/remotes/pins.py
@@ -1,0 +1,163 @@
+import logging
+import shutil
+import tempfile
+import os
+import zipfile
+import sys
+import pins
+from guild import remote as remotelib
+from guild import var
+from guild import remote_util
+
+from . import meta_sync
+
+log = logging.getLogger("guild.remotes.pins")
+
+RUNS_PATH = ["runs"]
+DELETED_RUNS_PATH = ["trash", "runs"]
+
+class PinsRemoteType(remotelib.RemoteType):
+    def __init__(self, _ep):
+        pass
+
+    def remote_for_config(self, name, config):
+        return PinsRemote(name, config)
+
+    def remote_for_spec (self, spec):
+        pass
+
+class PinsRemote (meta_sync.MetaSyncRemote):
+    def __init__(self, name, config):
+        self.name = name
+        board = config['board']
+        board_config = config['config']
+
+        self.subdir = config.get('subdir', '')
+
+        if board == 'temp':
+            raise ValueError(
+                "Pins remote does not support temp boards. "
+                "Use a folder board pointing to a temp directory instead."
+            )
+        elif board == 'folder':
+            self.board = pins.board_folder(**board_config)
+        elif board == 's3':
+            self.board = pins.board_s3(**board_config)
+        elif board == 'gcs':
+            self.board = pins.board_gcs(**board_config)
+        elif board == 'azure':
+            self.board = pins.board_azure(**board_config)
+        elif board == 'connect':
+            self.board = pins.board_connect(**board_config)
+        else:
+            raise RuntimeError(f"Unsupported board configuration {board}.")
+
+        self.local_env = remote_util.init_env(config.get("local-env"))
+        self.local_sync_dir = meta_sync.local_meta_dir(name, str(board_config))
+        runs_dir = os.path.join(self.local_sync_dir, *RUNS_PATH)
+        deleted_runs_dir = os.path.join(self.local_sync_dir, *DELETED_RUNS_PATH)
+        super().__init__(runs_dir, deleted_runs_dir)
+
+    def status(self, verbose=False):
+        sys.stdout.write(f"{self.name} (Pins board {str(self.board)}) is available\n")
+
+    def _sync_runs_meta(self, force=False):
+        remote_util.remote_activity(f"Refreshing run info for {self.name}")
+        runs = self.board.pin_search(self.subdir, as_df=True) if self.subdir else self.board.pin_search(as_df=True)
+        self._clear_runs_meta_dir()
+        for _, run in runs.iterrows():
+            meta_string = run.meta.user.get("guild_meta")
+            if meta_string is None:
+                continue
+            with tempfile.NamedTemporaryFile(mode= "wb") as temp:
+                _ = temp.write(bytes(meta_string))
+                temp.flush()
+                with zipfile.ZipFile(temp.name, mode="r") as zip_ref:
+                    expath = os.path.relpath(run["name"], self.subdir)
+                    path = os.path.join(self._runs_dir, expath, "")
+                    zip_ref.extractall(path)
+
+    def _clear_runs_meta_dir (self):
+        for root, dirs, files in os.walk(self._runs_dir):
+            for f in files:
+                os.unlink(os.path.join(root, f))
+            for d in dirs:
+                shutil.rmtree(os.path.join(root, d))
+        
+    def _purge_runs(self, runs):
+        raise NotImplementedError("Pins doesn't support non permanent deletion of runs.")
+     
+    def _restore_runs(self, runs):
+        raise NotImplementedError("Pins doesn't support non permanent deletion of runs.")
+    
+    def push(self, runs, delete = False):
+        remote_util.remote_activity("Pushing runs to pins board...")
+        for run in runs:
+            self._push_run(run, delete)
+        self._sync_runs_meta()
+
+    def _push_run(self, run, delete):
+
+        if not delete and self.board.pin_exists(self._get_run_pin_name(run.id)):
+            log.warning("Run %s already exists in pins board. Skipping.", self._get_run_pin_name(run.id))
+            return
+
+        with tempfile.TemporaryDirectory() as outdir:
+            archive_path = self._archive_run_dir(run.path, outdir)
+            metadata = self._archive_run_meta(run.path)
+            # TODO Currently pins doesn't support uploading files, so we read the archive into a binary
+            # string and use pin_write to upload it.
+            with open(archive_path, mode="rb") as f:
+                data = list(f.read())
+            self.board.pin_write(data, type="json", name=self._get_run_pin_name(run.id), versioned=True, metadata={"guild_meta": metadata})
+
+    def _archive_run_dir(self, dir, outfile):
+       return shutil.make_archive(outfile, 'zip', dir)
+    
+    def _archive_run_meta(self, run_path):
+        with tempfile.NamedTemporaryFile() as tmp:
+            with zipfile.ZipFile(tmp.name, "w") as zf:
+                for root, _, files in os.walk(run_path):
+                    for file in files:
+                        fname = os.path.join(root, file)
+                        relpath = os.path.relpath(fname, run_path)
+                        if _is_meta_file(fname):    
+                            zf.write(fname, relpath)
+            # now read the zip file into a bytestring
+            with open(tmp.name, "rb") as f:
+                data = f.read()
+            return data
+        
+    def pull(self, runs, delete=False):
+        for run in runs:
+            self._pull_run(run, delete)
+
+    def _pull_run(self, run, delete):
+        if delete:
+            raise ValueError("Unsupported delete op.")
+        archive = self.board.pin_read(self._get_run_pin_name(run.id))
+        with tempfile.NamedTemporaryFile(mode= "wb") as temp:
+            _ = temp.write(bytes(archive))
+            with zipfile.ZipFile(temp.name, mode="r") as zip_ref:
+                    zip_ref.extractall(os.path.join(var.runs_dir(), run.id, ""))
+
+    def _delete_runs(self, runs, permanent):
+        for run in runs:
+            if not permanent:
+                log.warning("Deleting pins runs is always permanent. Nothing will be deleted.")
+                return
+            try:
+                self.board.pin_delete(self._get_run_pin_name(run.id))
+            except pins.errors.PinsError as e:
+                log.warning("Failed to delete run %s: %s", self._get_run_pin_name(run.id), e)
+            except:
+                log.warning("Failed to delete run %s. Unknown error", self._get_run_pin_name(run.id))
+    
+    def _get_run_pin_name (self, run_id):
+        return os.path.join(self.subdir, run_id)
+            
+def _is_meta_file(name):
+    return (
+        name.endswith(".guild/opref") or "/.guild/attrs/" in name
+        or "/.guild/LOCK" in name
+    )

--- a/guild/tests/requirements.txt
+++ b/guild/tests/requirements.txt
@@ -10,3 +10,4 @@ matplotlib
 pandas
 tensorboardX
 twine
+pins

--- a/guild/tests/uat/README.md
+++ b/guild/tests/uat/README.md
@@ -308,4 +308,5 @@ Tests addressing various versions of TensorFlow, API changes, etc.
 - [remote-s3](remote-s3.md)
 - [remote-azure-blob](remote-azure-blob.md)
 - [remote-gist](remote-gist.md)
+- [remote-pins](remote-pins.md)
 - [remote-status](remote-status.md)

--- a/guild/tests/uat/remote-pins.md
+++ b/guild/tests/uat/remote-pins.md
@@ -1,0 +1,115 @@
+# Pins remote
+
+We first configure the pins remote:
+
+    >>> txt = open("/tmp/pins-test-config.yml", "wt")
+    >>> out = txt.write("""
+    ... remotes:
+    ...     guild-uat-pins:
+    ...         type: pins
+    ...         board: folder
+    ...         config:
+    ...             path: /tmp/pins-local-folder
+    ...             
+    ... """)
+    >>> txt.close()
+
+Override `run` so we always use the configuration above
+
+    >>> _run = run
+    >>> def run(x):
+    ...     _run(f"GUILD_CONFIG='/tmp/pins-test-config.yml' {x}")
+    >>> run("rm -rf /tmp/pins-local-folder")
+    <exit 0>
+
+Now check status works:
+
+    >>> run("guild remote status guild-uat-pins")
+    guild-uat-pins (Pins board ...) is available
+    <exit 0>
+
+Make some test runs:
+
+    >>> cd(example("hello"))
+    >>> quiet("guild runs rm -y")
+    
+    >>> run("guild run -y hello msg='hello run-1' --label run-1")
+    hello run-1
+    <exit 0>
+    
+    >>> run("guild run -y hello msg='hello run-2' --label run-2")
+    hello run-2
+    <exit 0>
+
+Push runs to pins remote:
+
+    >>> run("guild runs push guild-uat-pins -y")
+    Pushing runs to pins board...
+    ...
+    Refreshing run info for guild-uat-pins
+    <exit 0>
+
+List remote runs:
+
+    >>> run("guild runs list --remote guild-uat-pins")
+    Refreshing run info for guild-uat-pins
+    [1:...]  hello  ...  completed  run-2
+    [2:...]  hello  ...  completed  run-1
+    <exit 0>
+
+Pushing the same runs again should be a no-op:
+
+    >>> run("guild runs push guild-uat-pins -y")
+    Pushing runs to pins board...
+    WARNING: Run ... already exists in pins board. Skipping.
+    WARNING: Run ... already exists in pins board. Skipping.
+    Refreshing run info for guild-uat-pins
+    <exit 0>
+
+    >>> run("guild runs list --remote guild-uat-pins")
+    Refreshing run info for guild-uat-pins
+    [1:...]  hello  ...  completed  run-2
+    [2:...]  hello  ...  completed  run-1
+    <exit 0>
+
+Show remote run info:
+
+    >>> run("guild runs info --remote guild-uat-pins")
+    Refreshing run info for guild-uat-pins
+    id: ...
+    operation: hello
+    ...
+    <exit 0>
+
+Pull runs
+
+    >>> run("guild runs delete -y")
+    Deleted 2 run(s)
+    <exit 0>
+    >>> run("guild runs list")
+    <exit 0>
+    >>> run("guild runs pull guild-uat-pins -y")
+    Refreshing run info for guild-uat-pins
+    >>> run("guild runs list")
+    [1:...]  hello  ...  completed  run-2
+    [2:...]  hello  ...  completed  run-1
+
+Delete runs from remote
+
+    >>> run("guild runs delete --remote guild-uat-pins -y")
+    Refreshing run info for guild-uat-pins
+    WARNING: Deleting pins runs is always permanent. Nothing will be deleted.
+    Refreshing run info for guild-uat-pins
+    <exit 0>
+
+    >>> run("guild runs delete --remote guild-uat-pins -y --permanent")
+    Refreshing run info for guild-uat-pins
+    Refreshing run info for guild-uat-pins
+    <exit 0>
+
+    >>> run("guild runs list --remote guild-uat-pins")
+    Refreshing run info for guild-uat-pins
+    <exit 0>
+
+
+    

--- a/guildai.dist-info/entry_points.txt
+++ b/guildai.dist-info/entry_points.txt
@@ -43,3 +43,4 @@ ec2 = guild.remotes.ec2:EC2RemoteType
 gist = guild.remotes.gist:GistRemoteType
 s3 = guild.remotes.s3:S3RemoteType
 ssh = guild.remotes.ssh:SSHRemoteType
+pins = guild.remotes.pins:PinsRemoteType


### PR DESCRIPTION
This PR adds [pins](https://rstudio.github.io/pins-python/intro.html) as a `remote` option. 
Pins remotes are used to store runs directories, like the s3 and gist remotes. The nice thing about pins is that it supports Posit Connect :) It also supports other boards, such as GCS, Azure and S3 and it should work for all of them without additional work.

A few current design decisions that we might want to discuss:

- Each run is a stored as a pin. Another option would be to make each pin a collection of runs, but since pins does automatic versioning, adding a new run would require uploading all runs again.

- Currently we are archiving the run directory and uploading it as a binary string. This is not ideal and wont scale for larger runs directories. Pins allows access to `board.fs` which is the `fsspec` object, thus allowing access as a virtual file system which would allow us to more efficiently upload the run files, however we would need to reimplement metadata handling, versioning, etc. I think it would be nicer if pins allowed us to point to a directory and did all the work, instead of us reimplementing the metadata stuff.

----

Additional info:

To configure with connect you can add somethign like this to the `guild-config.yml` file:

```
connect:
    type: pins
    board: connect
    subdir: daniel # the subdir is important and must be a username for which you have write access
    config:
      server_url: ***
      api_key: ***
```
