### PR TITLE
Bugfix: Plugins were activated even when not configured

### DIFF
--- a/guild/commands/run_impl.py
+++ b/guild/commands/run_impl.py
@@ -464,7 +464,7 @@ def _iter_plugins():
 def _plugin_selected_for_op(plugin, opdef, configured_plugins):
     return (
         _configured_plugin(plugin, configured_plugins)
-        or _plugin_enabled_for_op(plugin, opdef)
+        and _plugin_enabled_for_op(plugin, opdef)
     )
 
 


### PR DESCRIPTION
Even if no plugin was configured, the plugins cpu,disk,memory,perf and python_script were activated due to the use of an "or" instead of an "and" operator in the function used to determine which plugins to use.

You can see the effect by running `guild run --print-env`. Without this patch, `GUILD_PLUGINS=cpu,disk,gpu,memory,perf,python_script` shows up even when no plugins were configured.